### PR TITLE
Result expectancy

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -307,6 +307,10 @@ function getHighestRating ( list ) {
             highestProg = modes[i][1].prog;
         }
     }
+    if (highestProg > 0)
+        highestProg = "+" + highestProg;
+    else if (highestProg == 0)
+        highestProg = "=0";
 
 	var formattedMessage = " (" + highestRating + " " + highestProg + " " + highestMode + ")";
 	return formattedMessage;

--- a/commands.js
+++ b/commands.js
@@ -244,7 +244,7 @@ function formatSummary ( data ) {
 		"Favorite mode: " + getMostPlayed( data.perfs ) + "\n" + 
         "Time played: " + secondsToHours( data.playTime.total ) + " hours" + "\n" +
 		"Completion rate: " + data.completionRate + "\n" +
-		"Win rate: " + getWinrate( data ) + "\n" +
+		"Win expectancy: " + getWinExpectancy( data ) + "\n" +
 		"```";
 	return formattedMessage;
 }
@@ -325,9 +325,10 @@ function modesArray ( list ) {
     }
     return array;
 }
-// Get winrate percentage
-function getWinrate ( list ) {
-	return ( list.count.win / list.count.all * 100 )+ "%";
+// Get win/result expectancy (draws count as 0.5)
+function getWinExpectancy ( list ) {
+    var score = list.count.win + ( list.count.draw / 2 );
+	return ( score / list.count.all * 100 ).toFixed(1)+ "%";
 }
 function secondsToHours ( seconds ) {
     return ( ( seconds / 60 ) / 60 ).toFixed(2);

--- a/commands.js
+++ b/commands.js
@@ -240,7 +240,7 @@ function formatSummary ( data ) {
 		data.url + "\n" +
 		"```" +
 		"User: "+ data.username + getHighestRating( data.perfs ) + " (" + ( data.online ? "online" : "offline" ) + ")"+"\n"+ 
-		"Games: " + data.count.all + " (" + data.count.rated + " rated)\n"+
+		"Games: " + data.count.rated + " rated, " + data.count.unrated + " unrated\n"+
 		"Favorite mode: " + getMostPlayed( data.perfs ) + "\n" + 
         "Time played: " + secondsToHours( data.playTime.total ) + " hours" + "\n" +
 		"Completion rate: " + data.completionRate + "\n" +
@@ -290,7 +290,11 @@ function getMostPlayed( list ) {
             }
         }
     } 
-    var formattedMessage = mostPlayedMode + " (" + mostPlayedGames + " games, rated " + mostPlayedRating + " (" + mostPlayedProg + "))";
+    if (mostPlayedProg > 0)
+        mostPlayedProg = "+" + mostPlayedProg;
+    else if (mostPlayedProg == 0)
+        mostPlayedProg = "=0";
+    var formattedMessage = mostPlayedMode + " (" + mostPlayedGames + " games, rated " + mostPlayedRating + " " + mostPlayedProg + ")";
 	return formattedMessage;
 }
 // Get string with highest rating formatted for summary
@@ -312,7 +316,7 @@ function getHighestRating ( list ) {
     else if (highestProg == 0)
         highestProg = "=0";
 
-	var formattedMessage = " (" + highestRating + " " + highestProg + " " + highestMode + ")";
+	var formattedMessage = " (" + highestMode + " " + highestRating + " " + highestProg + ")";
 	return formattedMessage;
 }
 // For sorting through modes... lichess api does not put these in an array so we do it ourselves

--- a/commands.js
+++ b/commands.js
@@ -240,7 +240,7 @@ function formatSummary ( data ) {
 		data.url + "\n" +
 		"```" +
 		"User: "+ data.username + getHighestRating( data.perfs ) + " (" + ( data.online ? "online" : "offline" ) + ")"+"\n"+ 
-		"Games: " + data.count.rated + " rated, " + data.count.unrated + " unrated\n"+
+		"Games: " + data.count.rated + " rated, " + ( data.count.all - data.count.rated ) + " casual\n"+
 		"Favorite mode: " + getMostPlayed( data.perfs ) + "\n" + 
         "Time played: " + secondsToHours( data.playTime.total ) + " hours" + "\n" +
 		"Completion rate: " + data.completionRate + "\n" +

--- a/commands.js
+++ b/commands.js
@@ -276,6 +276,7 @@ function getMostPlayed( list ) {
     var modes = modesArray( list );
 	
     var mostPlayedMode = modes[0][0];
+    var mostPlayedRD = modes[0][1].rd;
     var mostPlayedProg = modes[0][1].prog;
     var mostPlayedRating = modes[0][1].rating;
     var mostPlayedGames = modes[0][1].games;
@@ -284,6 +285,7 @@ function getMostPlayed( list ) {
         if ( modes[i][0] != 'puzzle' ) {
             if ( modes[i][1].games > mostPlayedGames) {
                 mostPlayedMode = modes[i][0];
+                mostPlayedRD = modes[i][1].rd;
                 mostPlayedProg = modes[i][1].prog;
                 mostPlayedRating = modes[i][1].rating;
                 mostPlayedGames = modes[i][1].games;
@@ -294,7 +296,9 @@ function getMostPlayed( list ) {
         mostPlayedProg = "+" + mostPlayedProg;
     else if (mostPlayedProg == 0)
         mostPlayedProg = "=0";
-    var formattedMessage = mostPlayedMode + " (" + mostPlayedGames + " games, rated " + mostPlayedRating + " " + mostPlayedProg + ")";
+
+    var formattedMessage = mostPlayedMode + " (" + mostPlayedGames + " games, " +
+        mostPlayedRating + " ± " + ( 2 * mostPlayedRD ) + " " + mostPlayedProg + ")";
 	return formattedMessage;
 }
 // Get string with highest rating formatted for summary
@@ -302,13 +306,17 @@ function getHighestRating ( list ) {
     var modes = modesArray( list );
 
     var highestMode = modes[0][0];
+    var highestRD = modes[0][1].rd;
     var highestProg = modes[0][1].prog;
     var highestRating = modes[0][1].rating;
+    var highestGames = modes[0][1].games;
     for ( var i = 0; i < list.length; i++ ) {
         if ( modes[i][1].rating > highestRating) {
             highestRating = modes[i].rating;
             highestMode = modes[i][0];
+            highestRD = modes[i][1].rd;
             highestProg = modes[i][1].prog;
+            highestGames = modes[i][1].games;
         }
     }
     if (highestProg > 0)
@@ -316,7 +324,8 @@ function getHighestRating ( list ) {
     else if (highestProg == 0)
         highestProg = "=0";
 
-	var formattedMessage = " (" + highestMode + " " + highestRating + " " + highestProg + ")";
+    var formattedMessage = " (" + highestMode + " " + highestGames + " games, " +
+        highestRating + " ± " + ( 2 * highestRD ) + " " + highestProg + ")";
 	return formattedMessage;
 }
 // For sorting through modes... lichess api does not put these in an array so we do it ourselves

--- a/commands.js
+++ b/commands.js
@@ -293,12 +293,14 @@ function getMostPlayed( list ) {
         }
     } 
     if (mostPlayedProg > 0)
-        mostPlayedProg = "+" + mostPlayedProg;
-    else if (mostPlayedProg == 0)
-        mostPlayedProg = "=0";
+        mostPlayedProg = " ▲" + mostPlayedProg;
+    else if (mostPlayedProg < 0)
+        mostPlayedProg = " ▼" + Math.abs( mostPlayedProg );
+    else
+        mostPlayedProg = "";
 
     var formattedMessage = mostPlayedMode + " (" + mostPlayedGames + " games, " +
-        mostPlayedRating + " ± " + ( 2 * mostPlayedRD ) + " " + mostPlayedProg + ")";
+        mostPlayedRating + " ± " + ( 2 * mostPlayedRD ) + mostPlayedProg + ")";
 	return formattedMessage;
 }
 // Get string with highest rating formatted for summary
@@ -320,12 +322,14 @@ function getHighestRating ( list ) {
         }
     }
     if (highestProg > 0)
-        highestProg = "+" + highestProg;
-    else if (highestProg == 0)
-        highestProg = "=0";
+        highestProg = " ▲" + highestProg;
+    else if (highestProg < 0)
+        highestProg = " ▼" + Math.abs( highestProg );
+    else
+        highestProg = "";
 
     var formattedMessage = " (" + highestMode + " " + highestGames + " games, " +
-        highestRating + " ± " + ( 2 * highestRD ) + " " + highestProg + ")";
+        highestRating + " ± " + ( 2 * highestRD ) + highestProg + ")";
 	return formattedMessage;
 }
 // For sorting through modes... lichess api does not put these in an array so we do it ourselves


### PR DESCRIPTION
I changed many things about how ratings display in response to `!summary`:

https://lichess.org/@/Toadofsky

```
User: Toadofsky (chess960 49 games, 1968 ± 144 ▼10) (offline)
Games: 6069 rated, 1253 casual
Favorite mode: blitz (2349 games, 2069 ± 128 ▲1)
Time played: 630.09 hours
Completion rate: undefined
Win expectancy: 68.0%
```